### PR TITLE
Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.10.2
+- [Fix getLocalRef() returns wrong ref](https://github.com/dorny/paths-filter/pull/91)
+
 ## v2.10.1
 - [Improve robustness of change detection](https://github.com/dorny/paths-filter/pull/85)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4015,8 +4015,9 @@ async function getLocalRef(shortName) {
     const output = (await exec_1.default('git', ['show-ref', shortName], { ignoreReturnCode: true })).stdout;
     const refs = output
         .split(/\r?\n/g)
-        .map(l => { var _a, _b; return (_b = (_a = l.match(/refs\/.*$/)) === null || _a === void 0 ? void 0 : _a[0]) !== null && _b !== void 0 ? _b : ''; })
-        .filter(l => l !== '');
+        .map(l => l.match(/refs\/(?:(?:heads)|(?:tags)|(?:remotes\/origin))\/(.*)$/))
+        .filter(match => match !== null && match[1] === shortName)
+        .map(match => { var _a; return (_a = match === null || match === void 0 ? void 0 : match[0]) !== null && _a !== void 0 ? _a : ''; }); // match can't be null here but compiler doesn't understand that
     if (refs.length === 0) {
         return undefined;
     }

--- a/src/git.ts
+++ b/src/git.ts
@@ -215,8 +215,9 @@ async function getLocalRef(shortName: string): Promise<string | undefined> {
   const output = (await exec('git', ['show-ref', shortName], {ignoreReturnCode: true})).stdout
   const refs = output
     .split(/\r?\n/g)
-    .map(l => l.match(/refs\/.*$/)?.[0] ?? '')
-    .filter(l => l !== '')
+    .map(l => l.match(/refs\/(?:(?:heads)|(?:tags)|(?:remotes\/origin))\/(.*)$/))
+    .filter(match => match !== null && match[1] === shortName)
+    .map(match => match?.[0] ?? '') // match can't be null here but compiler doesn't understand that
 
   if (refs.length === 0) {
     return undefined


### PR DESCRIPTION
git show-ref will return all branches where end segment matches the input. This cause issues when there are both 'someBranch' and 'somePrefix/someBranch' branches. This fix ensures the correct ref is returned by explicitly matching segments after common parts (e.g. refs/heads).